### PR TITLE
ハイフネーション禁止を削除

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -27,11 +27,6 @@ $endfor$
 \usepackage[dvipdfmx]{graphicx}
 \usepackage[dvipdfmx]{hyperref}
 
-% ハイフネーション禁止
-\hyphenpenalty=10000\relax
-\exhyphenpenalty=10000\relax
-\sloppy
-
 
 % ここまで
 


### PR DESCRIPTION
- 改行付近に文字数の多い単語のときにハイフンで区切るのを禁止してたのを無くしました